### PR TITLE
Add Personal Sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Next, run seacrest, specifying an Ethereum node to proxy requests to:
 seacrest http://goerli.infura.io 8585
 ```
 
-Now, you can specify `http://localhost:8585` as your Ethereum node in any service. If that service requests..
+Now, you can specify `http://localhost:8585` as your Ethereum node in any service. If that service calls `eth_accounts`, `eth_sendTransaction`, `net_version`, or `personal_sign`, that request will be intercepted by Seacrest and passed to WalletConnect. Otherwise, the request will be proxied the given Ethereum node.
 
 ### GitHub Actions
 
@@ -33,23 +33,33 @@ Seacrest is also meant to be easily used in a GitHub Action. Add to your YAML fi
 - name: Seacrest
   uses: hayesgm/seacrest@v1
   with:
-    ethereum_url: https://goerli.infura.io
-    port: 8585
+    ethereum_url: https://goerli.infura.io # optional, otherwise mainnet
+    port: 8585 # default 8585
 ```
 
 You will need to pull into your logs *when the action is running* and connect your wallet. Pull into the action log and scan the QR code. It's a little finnicky, but it should work.
 
 Subsequently, you can simply use `http://localhost:8585` as your Ethereum node. Any requests for accounts or signatures will be redirected to WalletConnect. For instance, you could deploy scripts from Hardhat using this node, with the security of WalletConnect but the ease and transparency of GitHub Actions.
 
+### Configuration
+
+You can configure the following values from the environment:
+
+* `ETHEREUM_URL`: Ethereum node to proxy to
+* `PORT`: Port to bind on
+* `LARGE`: Show full size QR code or compact
+* `RESHOW_DELAY`: Reshow the QR code every so often (used in GitHub Actions)
+* `REQUESTED_NETWORK`: Network to try to connect with- will fail if user connects to wrong network.
+
 ## Why?
 
-First, for fun and profit. But moreso, there's value in interacting and deploying Ethereum contracts in plain sight. But that's hard to do since most people don't want to share private keys with GitHub Secrets, even if they are throwaways. This gives developers the option to securely sign transactions _in public_.
+First, for fun ~~and profit~~. Moreso, there's value in interacting and deploying Ethereum contracts in plain sight. But that's hard to do since most people don't want to share private keys with GitHub Secrets, even if they are throw-aways. This gives developers the option to securely sign transactions _in public_.
 
 Secondly, you could use this as an authorization flow in GitHub Actions, e.g. to unlock other secrets or anything else. It is the first "human in the loop" authorization action that I know of.
 
 ## Contributing
 
-Create a PR to contribute to Signet. All contributors agree to accept the license specified in this repository for all contributions to this project. See [LICENSE.md](/LICENSE.md).
+Create a PR to contribute to Seacrest. All contributors agree to accept the license specified in this repository for all contributions to this project. See [LICENSE.md](/LICENSE.md).
 
 Feel free to create Feature Requests in the issues.
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ inputs:
   ethereum_url:
     description: "Ethereum node to proxy requests to"
     required: true
+    default: "https://mainnet.infura.io"
   port:
     description: "Port to host proxy on"
     required: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,22 @@
 {
   "name": "seacrest",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "seacrest",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "1.2.0",
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.0",
         "@walletconnect/node": "^1.0.0",
         "node-fetch": "^3.2.10",
         "qrcode-terminal": "^0.12.0",
         "tslib": "^2.4.0"
+      },
+      "bin": {
+        "seacrest": "src/index.mjs"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "seacrest",
   "type": "module",
-  "version": "0.0.2",
+  "version": "1.2.0",
   "description": "WalletConnect over the terminal or GitHub Actions",
   "main": "src/index.mjs",
+  "bin": {
+    "seacrest": "src/index.mjs"
+  },
   "scripts": {
     "start": "node src/index.mjs"
   },

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2,7 +2,7 @@ import { startServer } from "./server.mjs";
 
 const host = process.argv[2] || process.env["ETHEREUM_URL"];
 if (!host) {
-  throw new Error("Missing required ETHEREUM_URL");
+  host = 'https://mainnet.infura.io';
 }
 if (!host.startsWith("http")) {
   throw new Error(`Expected host to start with http, got: ${host}`);

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -21,10 +21,18 @@ async function eth_accounts(chainId, accounts, walletConnector, []) {
   return accounts;
 }
 
+async function personal_sign(chainId, accounts, walletConnector, [message, account]) {
+  return await walletConnector.signPersonalMessage([
+    message,
+    account
+  ]);
+}
+
 const rpcFuncs = {
   eth_sendTransaction,
   net_version,
   eth_accounts,
+  personal_sign
 };
 
 function getReqBody(req) {


### PR DESCRIPTION
This patch adds Personal Sign to Seacrest. We should consider if we still need a fallback network for this type of activity, thus we add a fallback to mainnet.