### PR TITLE
Fix Bin, Bump to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "seacrest",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "WalletConnect over the terminal or GitHub Actions",
   "main": "src/index.mjs",
   "bin": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,13 +1,16 @@
+#!/bin/sh
+":" //# comment; exec /usr/bin/env node --noharmony "$0" "$@"
 import { startServer } from "./server.mjs";
 
-const host = process.argv[2] || process.env["ETHEREUM_URL"];
-if (!host) {
-  host = 'https://mainnet.infura.io';
-}
+let host = process.argv[2] || process.env["ETHEREUM_URL"] || 'https://mainnet.infura.io';
 if (!host.startsWith("http")) {
   throw new Error(`Expected host to start with http, got: ${host}`);
 }
-const port = Number(process.argv[3] || process.env["PORT"] || 8585);
+const portStr = process.argv[3] || process.env["PORT"] || 8585;
+const port = Number(portStr);
+if (Number.isNaN(port)) {
+  throw new Error(`Invalid port ${portStr}`);
+}
 let connectOpts = {};
 if (process.env["LARGE"] === "false") {
   connectOpts.large = false;


### PR DESCRIPTION
This patch makes sure the bin is available generally if you run `npm install -g seacrest` then just being able to run `seacrest`.