### PR TITLE
Remove trailing slash in proxyUrl

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -46,9 +46,8 @@ function getReqBody(req) {
 
 async function proxy(host, request, reqBody, response) {
   let pathname = url.parse(request.url).pathname;
-  pathname = pathname === "/" ? "" : pathname; // to avoid a trailing slash
   let hostname = url.parse(host).host;
-  let proxyUrl = `${host}${pathname}`;
+  let proxyUrl = `${host}${pathname}`.replace(/\/+$/, ""); // remove trailing slashes
   let reqMethod = request.method;
   let reqHeaders = {
     ...request.headers,

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -46,6 +46,7 @@ function getReqBody(req) {
 
 async function proxy(host, request, reqBody, response) {
   let pathname = url.parse(request.url).pathname;
+  pathname = pathname === "/" ? "" : pathname; // to avoid a trailing slash
   let hostname = url.parse(host).host;
   let proxyUrl = `${host}${pathname}`;
   let reqMethod = request.method;

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -46,8 +46,9 @@ function getReqBody(req) {
 
 async function proxy(host, request, reqBody, response) {
   let pathname = url.parse(request.url).pathname;
+  pathname = pathname === "/" ? "" : pathname; // to avoid a trailing slash
   let hostname = url.parse(host).host;
-  let proxyUrl = `${host}${pathname}`.replace(/\/+$/, ""); // remove trailing slashes
+  let proxyUrl = `${host}${pathname}`;
   let reqMethod = request.method;
   let reqHeaders = {
     ...request.headers,


### PR DESCRIPTION
Infura has trouble handling requests with a trailing slash in API endpoint. https://github.com/INFURA/infura/issues/221

Credit to 🍯 for the find